### PR TITLE
fix the class name reference of inner class of generics

### DIFF
--- a/src/main/java/org/vafer/jdependency/Clazzpath.java
+++ b/src/main/java/org/vafer/jdependency/Clazzpath.java
@@ -31,6 +31,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.objectweb.asm.ClassReader;
 import org.vafer.jdependency.asm.DependenciesClassAdapter;
+import org.vafer.jdependency.utils.DependencyUtils;
 
 public final class Clazzpath {
 
@@ -191,9 +192,11 @@ public final class Clazzpath {
             clazzes.put(clazzName, clazz);
             unitClazzes.put(clazzName, clazz);
 
-            final DependenciesClassAdapter v = new DependenciesClassAdapter();
-            new ClassReader(resource.getInputStream()).accept(v, ClassReader.EXPAND_FRAMES | ClassReader.SKIP_DEBUG);
-            final Set<String> depNames = v.getDependencies();
+//            final DependenciesClassAdapter v = new DependenciesClassAdapter();
+//            new ClassReader(resource.getInputStream()).accept(v, ClassReader.EXPAND_FRAMES | ClassReader.SKIP_DEBUG);
+//            final Set<String> depNames = v.getDependencies();
+            
+            final Set<String> depNames = DependencyUtils.getDependenciesOfClass(resource.getInputStream());
 
             for (String depName : depNames) {
 

--- a/src/main/java/org/vafer/jdependency/asm/DependenciesClassAdapter.java
+++ b/src/main/java/org/vafer/jdependency/asm/DependenciesClassAdapter.java
@@ -25,6 +25,7 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.Remapper;
 import org.objectweb.asm.commons.RemappingClassAdapter;
+import org.objectweb.asm.signature.SignatureVisitor;
 
 public final class DependenciesClassAdapter extends RemappingClassAdapter {
 
@@ -42,10 +43,15 @@ public final class DependenciesClassAdapter extends RemappingClassAdapter {
 
         final Set<String> classes = new HashSet<String>();
 
+        @Override
+        protected SignatureVisitor createRemappingSignatureAdapter(SignatureVisitor v) {
+            return new SignatureRemapper(v, this);
+        }
+
         public String map(String pClassName) {
             classes.add(pClassName.replace('/', '.'));
             return pClassName;
-        }       
+        }
     }
 
     static class EmptyVisitor extends ClassVisitor

--- a/src/main/java/org/vafer/jdependency/asm/SignatureRemapper.java
+++ b/src/main/java/org/vafer/jdependency/asm/SignatureRemapper.java
@@ -1,0 +1,175 @@
+/***
+ * ASM: a very small and fast Java bytecode manipulation framework
+ * Copyright (c) 2000-2011 INRIA, France Telecom
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holders nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.vafer.jdependency.asm;
+
+//import java.util.ArrayDeque;
+import java.util.Stack;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.signature.SignatureVisitor;
+
+/**
+ * A {@link SignatureVisitor} adapter for type mapping.
+ * 
+ * @author Eugene Kuleshov
+ */
+public class SignatureRemapper extends SignatureVisitor {
+
+    private final SignatureVisitor v;
+
+    private final org.objectweb.asm.commons.Remapper remapper;
+
+    private Stack/*ArrayDeque*/<String> classNameStack = new Stack<String>();
+
+    private String getClassName() {
+        return classNameStack.peek();
+    }
+
+    private void setClassName(String className) {
+        popClassName();
+        pushClassName(className);
+    }
+    
+    private void pushClassName(String className) {
+        classNameStack.push(className);
+    }
+    
+    private void popClassName() {
+        classNameStack.pop();
+    }
+
+    public SignatureRemapper(final SignatureVisitor v, final org.objectweb.asm.commons.Remapper remapper) {
+        this(Opcodes.ASM5, v, remapper);
+    }
+
+    protected SignatureRemapper(final int api, final SignatureVisitor v,
+            final org.objectweb.asm.commons.Remapper remapper) {
+        super(api);
+        this.v = v;
+        this.remapper = remapper;
+    }
+
+    @Override
+    public void visitClassType(String name) {
+        pushClassName(name);
+        v.visitClassType(remapper.mapType(name));
+    }
+
+    @Override
+    public void visitInnerClassType(String name) {
+        String remappedOuter = remapper.mapType(getClassName()) + '$';
+        setClassName(getClassName() + '$' + name);
+        String remappedName = remapper.mapType(getClassName());
+        int index = remappedName.startsWith(remappedOuter) ? remappedOuter
+                .length() : remappedName.lastIndexOf('$') + 1;
+        v.visitInnerClassType(remappedName.substring(index));
+    }
+
+    @Override
+    public void visitFormalTypeParameter(String name) {
+        v.visitFormalTypeParameter(name);
+    }
+
+    @Override
+    public void visitTypeVariable(String name) {
+        v.visitTypeVariable(name);
+    }
+
+    @Override
+    public SignatureVisitor visitArrayType() {
+        v.visitArrayType();
+        return this;
+    }
+
+    @Override
+    public void visitBaseType(char descriptor) {
+        v.visitBaseType(descriptor);
+    }
+
+    @Override
+    public SignatureVisitor visitClassBound() {
+        v.visitClassBound();
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitExceptionType() {
+        v.visitExceptionType();
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitInterface() {
+        v.visitInterface();
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitInterfaceBound() {
+        v.visitInterfaceBound();
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitParameterType() {
+        v.visitParameterType();
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitReturnType() {
+        v.visitReturnType();
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitSuperclass() {
+        v.visitSuperclass();
+        return this;
+    }
+
+    @Override
+    public void visitTypeArgument() {
+        v.visitTypeArgument();
+    }
+
+    @Override
+    public SignatureVisitor visitTypeArgument(char wildcard) {
+        v.visitTypeArgument(wildcard);
+        return this;
+    }
+
+    @Override
+    public void visitEnd() {
+        v.visitEnd();
+        popClassName();
+    }
+}

--- a/src/main/java/org/vafer/jdependency/utils/DependencyUtils.java
+++ b/src/main/java/org/vafer/jdependency/utils/DependencyUtils.java
@@ -66,7 +66,7 @@ public final class DependencyUtils {
 
     public static Set<String> getDependenciesOfClass( final InputStream pInputStream ) throws IOException {
         final DependenciesClassAdapter v = new DependenciesClassAdapter();
-        new ClassReader( pInputStream ).accept( v, ClassReader.EXPAND_FRAMES );
+        new ClassReader( pInputStream ).accept( v, ClassReader.EXPAND_FRAMES | ClassReader.SKIP_DEBUG );
         final Set<String> depNames = v.getDependencies();
         return depNames;
     }

--- a/src/test/java/org/vafer/jdependency/VariousClassSignatureTestCase.java
+++ b/src/test/java/org/vafer/jdependency/VariousClassSignatureTestCase.java
@@ -1,0 +1,67 @@
+package org.vafer.jdependency;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import org.hamcrest.core.AnyOf;
+import org.junit.Assert;
+import org.junit.Test;
+import org.vafer.jdependency.VariousClassSignatureTestCase.Generics.GenericsNested;
+import org.vafer.jdependency.VariousClassSignatureTestCase.GenericsExtendedAndBound.GenericNestedExtended;
+import org.vafer.jdependency.VariousClassSignatureTestCase.Nest1.Nest2;
+import org.vafer.jdependency.utils.DependencyUtils;
+
+public class VariousClassSignatureTestCase {
+
+    static class Nest1 {
+        static class Nest2 {
+        }
+    }
+
+    private static String nm(String class_getname) {
+        return class_getname;
+    }
+
+    private static <T extends Comparable<T>> String tostr(T... o) {
+        return tostr(Arrays.asList(o));
+    }
+
+    private static <T extends Comparable<T>> String tostr(Collection<T> o) {
+        List<T> x = new ArrayList<T>(o);
+        Collections.sort(x);
+        return x.toString();
+    }
+
+    @Test
+    public void testInnerClasses() throws IOException {
+        Assert.assertEquals(
+                tostr(nm(Nest1.class.getName()), nm(Nest2.class.getName()), nm(Object.class.getName()),
+                        nm(VariousClassSignatureTestCase.class.getName())),
+                tostr(DependencyUtils.getDependenciesOfClass(Nest2.class)));
+    }
+
+    static class Generics<T> {
+        class GenericsNested {
+        }
+    }
+
+    static class GenericsExtendedAndBound extends Generics<Object> {
+        class GenericNestedExtended extends GenericsNested {
+        }
+    }
+
+    @Test
+    public void testGenericsInnerClass() throws IOException {
+        Assert.assertEquals(
+                tostr(nm(GenericNestedExtended.class.getName()), nm(GenericsExtendedAndBound.class.getName()),
+                        nm(GenericsNested.class.getName()), nm(Generics.class.getName()), nm(Object.class.getName()),
+                        nm(VariousClassSignatureTestCase.class.getName())),
+                tostr(DependencyUtils.getDependenciesOfClass(GenericNestedExtended.class)));
+    }
+
+}


### PR DESCRIPTION
The asm library has a bug that the inner class name of generics class
cannot be correctly handled. I made a patch and some unit tests for this
problem.
