### PR TITLE
Added new feature Clazzpath.getClashedClazzesNotIdentical

### DIFF
--- a/src/main/java/org/vafer/jdependency/Clazz.java
+++ b/src/main/java/org/vafer/jdependency/Clazz.java
@@ -20,9 +20,9 @@ import java.util.Set;
 
 public final class Clazz implements Comparable<Clazz> {
 
-    private final Set<Clazz> dependencies = new HashSet<Clazz>();
-    private final Set<Clazz> references = new HashSet<Clazz>();
-    private final Set<ClazzpathUnit> units = new HashSet<ClazzpathUnit>();
+    private final Set<Clazz> dependencies = new HashSet<>();
+    private final Set<Clazz> references = new HashSet<>();
+    private final Set<ClazzpathUnit> units = new HashSet<>();
 
     private final String name;
 
@@ -62,15 +62,12 @@ public final class Clazz implements Comparable<Clazz> {
         return dependencies;
     }
 
-
-
     public Set<Clazz> getReferences() {
         return references;
     }
 
-
     public Set<Clazz> getTransitiveDependencies() {
-        final Set<Clazz> all = new HashSet<Clazz>();
+        final Set<Clazz> all = new HashSet<>();
         findTransitiveDependencies(all);
         return all;
     }
@@ -85,7 +82,8 @@ public final class Clazz implements Comparable<Clazz> {
         }
     }
 
-    public boolean equals( final Object pO ) {
+    @Override
+	public boolean equals( final Object pO ) {
         if (pO.getClass() != Clazz.class) {
             return false;
         }
@@ -93,15 +91,18 @@ public final class Clazz implements Comparable<Clazz> {
         return name.equals(c.name);
     }
 
-    public int hashCode() {
+    @Override
+	public int hashCode() {
         return name.hashCode();
     }
 
-    public int compareTo( final Clazz pO ) {
-        return name.compareTo(((Clazz) pO).name);
+    @Override
+	public int compareTo( final Clazz pO ) {
+        return name.compareTo(pO.name);
     }
 
-    public String toString() {
+    @Override
+	public String toString() {
         return name;
     }
 

--- a/src/main/java/org/vafer/jdependency/ClazzpathUnit.java
+++ b/src/main/java/org/vafer/jdependency/ClazzpathUnit.java
@@ -33,29 +33,27 @@ public final class ClazzpathUnit {
     }
 
     public Set<Clazz> getClazzes() {
-        final Set<Clazz> result = new HashSet<Clazz>(clazzes.values());
-        return result;
+        return new HashSet<>(clazzes.values());
     }
 
     public Clazz getClazz( final String pClazzName ) {
-        final Clazz result = clazzes.get(pClazzName);
-        return result;
+        return clazzes.get(pClazzName);
     }
 
     public Set<Clazz> getDependencies() {
-        final Set<Clazz> result = new HashSet<Clazz>(dependencies.values());
-        return result;
+        return new HashSet<>(dependencies.values());
     }
 
     public Set<Clazz> getTransitiveDependencies() {
-        final Set<Clazz> all = new HashSet<Clazz>();
+        final Set<Clazz> all = new HashSet<>();
         for (Clazz clazz : clazzes.values()) {
             clazz.findTransitiveDependencies(all);
         }
         return all;
     }
 
-    public String toString() {
+    @Override
+	public String toString() {
         return id;
     }
 }

--- a/src/main/java/org/vafer/jdependency/asm/DependenciesClassAdapter.java
+++ b/src/main/java/org/vafer/jdependency/asm/DependenciesClassAdapter.java
@@ -17,7 +17,6 @@ package org.vafer.jdependency.asm;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.io.File;
 
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
@@ -47,9 +46,10 @@ public final class DependenciesClassAdapter extends ClassRemapper {
 
     private static class CollectingRemapper extends Remapper {
 
-        final Set<String> classes = new HashSet<String>();
+        final Set<String> classes = new HashSet<>();
 
-        public String map(String pClassName) {
+        @Override
+		public String map(String pClassName) {
             classes.add(pClassName.replace('/', '.'));
             return pClassName;
         }

--- a/src/main/java/org/vafer/jdependency/utils/DependencyUtils.java
+++ b/src/main/java/org/vafer/jdependency/utils/DependencyUtils.java
@@ -17,21 +17,15 @@ package org.vafer.jdependency.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.File;
-import java.util.HashSet;
 import java.util.Set;
-import java.util.jar.JarEntry;
-import java.util.jar.JarInputStream;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.output.NullOutputStream;
 import org.objectweb.asm.ClassReader;
 import org.vafer.jdependency.asm.DependenciesClassAdapter;
 
 /**
  * internal - do not use
  */
-final public class DependencyUtils {
+public final class DependencyUtils {
 
     /*
     public static Set<String> getDependenciesOfJar( final InputStream pInputStream ) throws IOException {
@@ -75,13 +69,11 @@ final public class DependencyUtils {
     public static Set<String> getDependenciesOfClass( final InputStream pInputStream ) throws IOException {
         final DependenciesClassAdapter v = new DependenciesClassAdapter();
         new ClassReader( pInputStream ).accept( v, ClassReader.EXPAND_FRAMES );
-        final Set<String> depNames = v.getDependencies();
-        return depNames;
+        return v.getDependencies();
     }
 
     public static Set<String> getDependenciesOfClass( final Class<?> pClass ) throws IOException {
-        final String resource = "/" + pClass.getName().replace('.', '/') + ".class";
+        final String resource = '/' + pClass.getName().replace('.', '/') + ".class";
         return getDependenciesOfClass(pClass.getResourceAsStream(resource));
     }
-
 }

--- a/src/test/java/org/vafer/jdependency/ClazzpathTestCase.java
+++ b/src/test/java/org/vafer/jdependency/ClazzpathTestCase.java
@@ -15,10 +15,10 @@
  */
 package org.vafer.jdependency;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,7 +31,10 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
 public class ClazzpathTestCase {
@@ -59,7 +62,7 @@ public class ClazzpathTestCase {
     }
 
     private static Set<ClazzpathUnit> unitSet(ClazzpathUnit[] ar) {
-        return new HashSet<ClazzpathUnit>(Arrays.asList(ar));
+        return new HashSet<>(Arrays.asList(ar));
     }
 
     /**
@@ -75,7 +78,8 @@ public class ClazzpathTestCase {
 
             new Object[] { new AddClazzpathUnit() {
 
-                ClazzpathUnit to(Clazzpath toClazzpath, String filename, String id) throws IOException {
+                @Override
+				ClazzpathUnit to(Clazzpath toClazzpath, String filename, String id) throws IOException {
                     final String p = filename + ".jar";
                     InputStream resourceAsStream = getClass()
                         .getClassLoader()
@@ -86,7 +90,8 @@ public class ClazzpathTestCase {
             }, "classpath"},
             new Object[] { new AddClazzpathUnit() {
 
-                ClazzpathUnit to(Clazzpath toClazzpath, String filename, String id) throws IOException {
+                @Override
+				ClazzpathUnit to(Clazzpath toClazzpath, String filename, String id) throws IOException {
                     final String p = filename + ".jar";
                     File file = resourceFile(p);
                     assertTrue("missing:" + file, file.exists() && file.isFile());
@@ -95,7 +100,8 @@ public class ClazzpathTestCase {
             }, "file-jar"},
             new Object[] { new AddClazzpathUnit() {
 
-                ClazzpathUnit to(Clazzpath toClazzpath, String filename, String id) throws IOException {
+                @Override
+				ClazzpathUnit to(Clazzpath toClazzpath, String filename, String id) throws IOException {
                     final String p = filename;
                     File file = resourceFile(p);
                     assertTrue("missing:" + file , file.exists() && file.isDirectory());
@@ -104,7 +110,8 @@ public class ClazzpathTestCase {
             }, "file-directory"},
             new Object[] { new AddClazzpathUnit() {
 
-                ClazzpathUnit to(Clazzpath toClazzpath, String filename, String id) throws IOException {
+                @Override
+				ClazzpathUnit to(Clazzpath toClazzpath, String filename, String id) throws IOException {
                     final String p = filename + ".jar";
                     Path path = resourcePath(p);
                     assertTrue("missing:" + path, Files.exists(path) && Files.isRegularFile(path));
@@ -113,7 +120,8 @@ public class ClazzpathTestCase {
             }, "path-jar"},
             new Object[] { new AddClazzpathUnit() {
 
-                ClazzpathUnit to(Clazzpath toClazzpath, String filename, String id) throws IOException {
+                @Override
+				ClazzpathUnit to(Clazzpath toClazzpath, String filename, String id) throws IOException {
                     final String p = filename;
                     Path path = resourcePath(p);
                     assertTrue("missing:" + path, Files.exists(path) && Files.isDirectory(path));
@@ -185,7 +193,7 @@ public class ClazzpathTestCase {
 
         final Set<Clazz> missing = cp.getMissingClazzes();
 
-        final Set<String> actual = new HashSet<String>();
+        final Set<String> actual = new HashSet<>();
         for (Clazz clazz : missing) {
             String name = clazz.getName();
             // ignore the rt
@@ -194,7 +202,7 @@ public class ClazzpathTestCase {
             }
         }
 
-        final Set<String> expected = new HashSet<String>(Arrays.asList(
+        final Set<String> expected = new HashSet<>(Arrays.asList(
             "org.apache.commons.io.output.ProxyOutputStream",
             "org.apache.commons.io.input.ProxyInputStream"
             ));

--- a/src/test/java/org/vafer/jdependency/ClazzpathUnitTestCase.java
+++ b/src/test/java/org/vafer/jdependency/ClazzpathUnitTestCase.java
@@ -15,23 +15,18 @@
  */
 package org.vafer.jdependency;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class ClazzpathUnitTestCase {
 
@@ -51,18 +46,18 @@ public class ClazzpathUnitTestCase {
         final ClazzpathUnit u1 = cp.addClazzpathUnit(resourceFile("cxf-core-3.4.0.jar"));
         final Set<String> u1f = u1.getClazzes().stream()
             .filter( i -> i.getName().contains("W3CSchema") )
-            .map( i -> i.getName() )
+            .map( Clazz::getName )
             .collect(Collectors.toSet());
-        final Set<String> u1fe = new HashSet<String>(Arrays.asList(
+        final Set<String> u1fe = new HashSet<>(Arrays.asList(
             ));
         assertEquals(u1fe, u1f);
 
         final ClazzpathUnit u2 = cp.addClazzpathUnit(resourceFile("woodstox-core-6.2.3.jar"));
         final Set<String> u2f = u2.getClazzes().stream()
             .filter( i -> i.getName().contains("W3CSchema") )
-            .map( i -> i.getName() )
+            .map( Clazz::getName )
             .collect(Collectors.toSet());
-        final Set<String> u2fe = new HashSet<String>(Arrays.asList(
+        final Set<String> u2fe = new HashSet<>(Arrays.asList(
             "com.ctc.wstx.msv.W3CSchemaFactory",
             "com.ctc.wstx.osgi.ValidationSchemaFactoryProviderImpl$W3CSchema",
             "com.ctc.wstx.msv.W3CSchema"
@@ -72,9 +67,9 @@ public class ClazzpathUnitTestCase {
         final Set<String> units = cp.getClazzes().stream()
             .filter( i -> i.getName().contains("W3CSchema") )
             .flatMap( i -> i.getClazzpathUnits().stream() )
-            .map( i -> i.toString() )
+            .map( ClazzpathUnit::toString )
             .collect(Collectors.toSet());
-        final Set<String> unitse = new HashSet<String>(Arrays.asList(
+        final Set<String> unitse = new HashSet<>(Arrays.asList(
             "woodstox-core-6.2.3.jar"
             ));
         assertEquals(unitse, units);
@@ -86,9 +81,9 @@ public class ClazzpathUnitTestCase {
 
         final ClazzpathUnit u = cp.addClazzpathUnit(resourceFile("jar1.jar"));
         final Set<String> uc = u.getClazzes().stream()
-            .map(c -> c.getName())
+            .map(Clazz::getName)
             .collect(Collectors.toSet());
-        final Set<String> uce = new HashSet<String>(Arrays.asList(
+        final Set<String> uce = new HashSet<>(Arrays.asList(
             "org.apache.commons.io.filefilter.IOFileFilter",
             "org.apache.commons.io.LineIterator",
             "org.apache.commons.io.output.NullWriter",

--- a/src/test/java/org/vafer/jdependency/DependencyUtilsTestCase.java
+++ b/src/test/java/org/vafer/jdependency/DependencyUtilsTestCase.java
@@ -48,7 +48,7 @@ public final class DependencyUtilsTestCase {
     @Test
     public void testShouldFindDependenciesOfClassObject() throws Exception {
         final Set<String> dependencies = DependencyUtils.getDependenciesOfClass(Object.class);
-        final Set<String> expectedDependencies = new HashSet<String>(Arrays.asList(
+        final Set<String> expectedDependencies = new HashSet<>(Arrays.asList(
                 "java.lang.String",
                 "java.lang.IllegalArgumentException",
                 "java.lang.CloneNotSupportedException",


### PR DESCRIPTION
Some Java libraries (even Java EE / Jakarta EE) split the functionality into several Jars. This Jars can include byte identical classes. This classpath clashes might be tolerated by the developers. For this reason included a twin to Clazzpath.getClashedClazzes which does a bytewise comparison to clash classes and ignore identical classes.

ps. also did some java 8 cleanup (Mainly SonarLint suggestions)