### PR TITLE
Use ASM9 Opcodes, add missing non-void overrides

### DIFF
--- a/src/main/java/org/vafer/jdependency/asm/DependenciesClassAdapter.java
+++ b/src/main/java/org/vafer/jdependency/asm/DependenciesClassAdapter.java
@@ -17,23 +17,26 @@ package org.vafer.jdependency.asm;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.io.File;
 
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.ModuleVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.RecordComponentVisitor;
 import org.objectweb.asm.TypePath;
 import org.objectweb.asm.commons.ClassRemapper;
 import org.objectweb.asm.commons.Remapper;
 
 /**
- * interal - do not use
+ * internal - do not use
  */
 
 public final class DependenciesClassAdapter extends ClassRemapper {
+
+    private static final int OPCODES = Opcodes.ASM9;
 
     private static final EmptyVisitor ev = new EmptyVisitor();
 
@@ -57,7 +60,7 @@ public final class DependenciesClassAdapter extends ClassRemapper {
 
     static class EmptyVisitor extends ClassVisitor {
 
-        private static final AnnotationVisitor av = new AnnotationVisitor(Opcodes.ASM7) {
+        private static final AnnotationVisitor av = new AnnotationVisitor(OPCODES) {
             @Override
             public AnnotationVisitor visitAnnotation(String name, String desc) {
                 return this;
@@ -69,7 +72,7 @@ public final class DependenciesClassAdapter extends ClassRemapper {
             }
         };
 
-        private static final MethodVisitor mv = new MethodVisitor( Opcodes.ASM6) {
+        private static final MethodVisitor mv = new MethodVisitor(OPCODES) {
             @Override
             public AnnotationVisitor visitAnnotationDefault() {
                 return av;
@@ -112,7 +115,7 @@ public final class DependenciesClassAdapter extends ClassRemapper {
             }
         };
 
-        private static final FieldVisitor fieldVisitor = new FieldVisitor( Opcodes.ASM7 ) {
+        private static final FieldVisitor fieldVisitor = new FieldVisitor(OPCODES) {
             @Override
             public AnnotationVisitor visitAnnotation( String desc, boolean visible ) {
                 return av;
@@ -124,8 +127,23 @@ public final class DependenciesClassAdapter extends ClassRemapper {
             }
         };
 
+        private static final ModuleVisitor moduleVisitor = new ModuleVisitor(OPCODES) {
+        };
+
+        private static final RecordComponentVisitor recordComponentVisitor = new RecordComponentVisitor(OPCODES) {
+            @Override
+            public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+                return av;
+            }
+
+            @Override
+            public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
+                return av;
+            }
+        };
+
         public EmptyVisitor() {
-            super(Opcodes.ASM7);
+            super(OPCODES);
         }
 
         @Override
@@ -147,6 +165,16 @@ public final class DependenciesClassAdapter extends ClassRemapper {
         public AnnotationVisitor visitTypeAnnotation( int typeRef, TypePath typePath, String descriptor,
                                                       boolean visible ) {
             return av;
+        }
+
+        @Override
+        public ModuleVisitor visitModule(String name, int access, String version) {
+            return moduleVisitor;
+        }
+
+        @Override
+        public RecordComponentVisitor visitRecordComponent(String name, String descriptor, String signature) {
+            return recordComponentVisitor;
         }
     }
 }


### PR DESCRIPTION
This fixes support for Records; would previously throw `java.lang.UnsupportedOperationException: Records requires ASM8`