### PR TITLE
Run github actions on Ubuntu+Windows on all LTS Java releases.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,9 @@ jobs:
   test:
     strategy:
       matrix:
-        java: [ 8, 19, 20 ]
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest, windows-latest]
+        java: [ 8, 11, 17, 21 ]
+    runs-on: ${{ matrix.os }}
     steps:
 
       - name: Checkout
@@ -18,7 +19,7 @@ jobs:
       - name: Setup
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Cache


### PR DESCRIPTION
Github actions supports building on Windows so the separate appveyor should not be needed.
In my opinion it should be run on all LTS Java versions.