### PR TITLE
Support GitHub releases on CI and update changelog formats

### DIFF
--- a/.github/workflows/release-ossrh.yml
+++ b/.github/workflows/release-ossrh.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   ossrh:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     environment: maven-central
+    permissions:
+      contents: write
     steps:
 
     - name: Checkout
@@ -39,3 +42,18 @@ jobs:
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+
+    - name: Extract release notes
+      uses: ffurrer2/extract-release-notes@v2
+      with:
+        changelog_file: HISTORY.md
+        release_notes_file: RELEASE_NOTES.md
+
+    - name: Create GitHub release
+      run: |
+        # Remove jdependency- prefix of the tag.
+        release_name="${GITHUB_REF_NAME#jdependency-}"
+        gh release create ${{ github.ref_name }} --title $release_name --notes-file RELEASE_NOTES.md
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/release-ossrh.yml
+++ b/.github/workflows/release-ossrh.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   ossrh:
     runs-on: ubuntu-latest
-#    if: github.event.repository.fork == false
+    if: github.event.repository.fork == false
     environment: maven-central
     permissions:
       contents: write
@@ -17,31 +17,31 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-#    - name: Version
-#      uses: tcurdt/action-verify-version-maven@main
-#
-#    - name: Setup Maven Central
-#      uses: actions/setup-java@v4
-#      with: # overwrite settings.xml
-#        distribution: 'zulu'
-#        java-version: 21
-#        server-id: ossrh
-#        server-username: OSSRH_USERNAME
-#        server-password: OSSRH_PASSWORD
-#        gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
-#        gpg-passphrase: MAVEN_GPG_PASSPHRASE
-#
-#    - name: Maven
-#      uses: stCarolas/setup-maven@v5
-#      with:
-#        maven-version: 3.9.6
-#
-#    - name: Publish to Maven Central
-#      run: mvn -B -Prelease --file pom.xml deploy
-#      env:
-#        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-#        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-#        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+    - name: Version
+      uses: tcurdt/action-verify-version-maven@main
+
+    - name: Setup Maven Central
+      uses: actions/setup-java@v4
+      with: # overwrite settings.xml
+        distribution: 'zulu'
+        java-version: 21
+        server-id: ossrh
+        server-username: OSSRH_USERNAME
+        server-password: OSSRH_PASSWORD
+        gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+    - name: Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.9.6
+
+    - name: Publish to Maven Central
+      run: mvn -B -Prelease --file pom.xml deploy
+      env:
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
     - name: Extract release notes
       uses: ffurrer2/extract-release-notes@v2

--- a/.github/workflows/release-ossrh.yml
+++ b/.github/workflows/release-ossrh.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Extract release notes
       uses: ffurrer2/extract-release-notes@v2
       with:
-        changelog_file: HISTORY.md
+        changelog_file: CHANGELOG.md
         release_notes_file: RELEASE_NOTES.md
 
     - name: Create GitHub release

--- a/.github/workflows/release-ossrh.yml
+++ b/.github/workflows/release-ossrh.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   ossrh:
     runs-on: ubuntu-latest
-    if: github.event.repository.fork == false
+#    if: github.event.repository.fork == false
     environment: maven-central
     permissions:
       contents: write
@@ -17,31 +17,31 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Version
-      uses: tcurdt/action-verify-version-maven@main
-
-    - name: Setup Maven Central
-      uses: actions/setup-java@v4
-      with: # overwrite settings.xml
-        distribution: 'zulu'
-        java-version: 21
-        server-id: ossrh
-        server-username: OSSRH_USERNAME
-        server-password: OSSRH_PASSWORD
-        gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
-        gpg-passphrase: MAVEN_GPG_PASSPHRASE
-
-    - name: Maven
-      uses: stCarolas/setup-maven@v5
-      with:
-        maven-version: 3.9.6
-
-    - name: Publish to Maven Central
-      run: mvn -B -Prelease --file pom.xml deploy
-      env:
-        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+#    - name: Version
+#      uses: tcurdt/action-verify-version-maven@main
+#
+#    - name: Setup Maven Central
+#      uses: actions/setup-java@v4
+#      with: # overwrite settings.xml
+#        distribution: 'zulu'
+#        java-version: 21
+#        server-id: ossrh
+#        server-username: OSSRH_USERNAME
+#        server-password: OSSRH_PASSWORD
+#        gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
+#        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+#
+#    - name: Maven
+#      uses: stCarolas/setup-maven@v5
+#      with:
+#        maven-version: 3.9.6
+#
+#    - name: Publish to Maven Central
+#      run: mvn -B -Prelease --file pom.xml deploy
+#      env:
+#        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+#        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+#        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
     - name: Extract release notes
       uses: ffurrer2/extract-release-notes@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased] - 2025-xx-xx
-[Unreleased]: https://github.com/tcurdt/jdependency/compare/jdependency-2.12..HEAD
+[Unreleased]: https://github.com/tcurdt/jdependency/compare/jdependency-2.13..HEAD
+
+
+## [2.13.0] - 2025-03-31
+[2.13.0]: https://github.com/tcurdt/jdependency/releases/tag/jdependency-2.13
 
 - Upgraded to ASM 9.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,20 @@
 ## [Unreleased] - 2025-xx-xx
-[Unreleased]: https://github.com/tcurdt/jdependency/compare/jdependency-2.12..HEAD
 
 - Upgraded to ASM 9.8
 
 
 ## [2.12.0] - 2025-02-02
-[2.12.0]: https://github.com/tcurdt/jdependency/releases/tag/jdependency-2.12
 
 - Upgraded to ASM 9.7.1 (JDK 24 support)
 
 
 ## [2.11.0] - 2024-11-18
-[2.11.0]: https://github.com/tcurdt/jdependency/releases/tag/jdependency-2.11
 
 - Upgraded to ASM 9.7 (JDK 23 support)
 - Changed minimum Java to 11
 
 
 ## [2.10.0] - 2024-01-25
-[2.10.0]: https://github.com/tcurdt/jdependency/releases/tag/jdependency-2.10
 
 - Upgraded to ASM 9.6
 - Upgraded other internal dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## [Unreleased] - 2025-xx-xx
-[Unreleased]: https://github.com/tcurdt/jdependency/compare/jdependency-2.13..HEAD
-
-
-## [2.13.0] - 2025-03-31
-[2.13.0]: https://github.com/tcurdt/jdependency/releases/tag/jdependency-2.13
+[Unreleased]: https://github.com/tcurdt/jdependency/compare/jdependency-2.12..HEAD
 
 - Upgraded to ASM 9.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,30 @@
-## Version 2.13.0, dev
+## [Unreleased] - 2025-xx-xx
+[Unreleased]: https://github.com/tcurdt/jdependency/compare/jdependency-2.12..HEAD
 
 - Upgraded to ASM 9.8
 
-## Version 2.12.0, release 02.02.2025
+
+## [2.12.0] - 2025-02-02
+[2.12.0]: https://github.com/tcurdt/jdependency/releases/tag/jdependency-2.12
 
 - Upgraded to ASM 9.7.1 (JDK 24 support)
 
-## Version 2.11.0, release 18.11.2024
+
+## [2.11.0] - 2024-11-18
+[2.11.0]: https://github.com/tcurdt/jdependency/releases/tag/jdependency-2.11
 
 - Upgraded to ASM 9.7 (JDK 23 support)
-- Changed minimum Java version to 11
+- Changed minimum Java to 11
 
-## Version 2.10.0, release 25.01.2024
+
+## [2.10.0] - 2024-01-25
+[2.10.0]: https://github.com/tcurdt/jdependency/releases/tag/jdependency-2.10
 
 - Upgraded to ASM 9.6
 - Upgraded other internal dependencies
 - Added support for multi release jars (Thanks to Niels Basjes)
 - Changed minimum Maven version to 3.6.3
+
 
 ## Version 2.9.0, release 11.08.2023
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,9 @@
 - mvn versions:display-dependency-updates
 - mvn versions:display-plugin-updates
 - update CHANGELOG.md
+  1. Change the `Unreleased` header to the release version.
+  2. Add a link URL to ensure the header link works.
+  3. Add a new `Unreleased` section to the top.
 - change version in pom.xml
 - push and wait for build
 - create tag jdependency-VERSION

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 - mvn verify
 - mvn versions:display-dependency-updates
 - mvn versions:display-plugin-updates
-- update HISTORY.md
+- update CHANGELOG.md
 - change version in pom.xml
 - push and wait for build
 - create tag jdependency-VERSION


### PR DESCRIPTION
You can view the test release at https://github.com/Goooler/jdependency/releases/tag/jdependency-2.13.

Users can subscribe to the release events like

<img width="1255" alt="image" src="https://github.com/user-attachments/assets/2b52ab99-fc45-43a6-be37-5895d873ddd9" />