### PR TITLE
ci: skip ci tests when only markdown files are changed in a push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: ci
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
### Change Summary
Currently, the `ci` workflow will run even when a push changes **only markdown files** (e.g., README.md).

With these changes, a push that changes *only* markdown files will not trigger the workflow, thus **speeding up the project's CI** and **saving compute resources** 🌱 (see below for quantity).

### Example
Here is an example of the behaviour described above: the commit [`27371d9`](https://github.com/tcurdt/jdependency/commit/27371d9434aa142b0e6d6644d9adbedef4a87974) changed these files: `README.md` and, when pushed, triggered [this](https://github.com/tcurdt/jdependency/actions/runs/13099181006) workflow run, which ran for ~5 CPU minutes. With the proposed changes, these 5 CPU minutes would have been saved, clearing the queue for other workflows and speeding up the CI of the project, while also saving resources in general. 

Note that this is a single example out of 8 examples over the last few months; a lower estimate for the accumulated gain is **1 CPU hour**, but the actual number could be higher because our cutoff date is late May and our data go only a few months back.

This only affects the `push` trigger and not the `pull_request` trigger, so the actions related to pull requests (opening, pushing new commits on an open PR, closing) will not be affected, only the pushes to branches which do not have an open pull request.

<details>
<summary>Click here to see all the recent CI runs triggered by markdown files.</summary>

[commit 27371d9](https://github.com/tcurdt/jdependency/commit/27371d9) => [run url](https://github.com/tcurdt/jdependency/actions/runs/13099181006)
[commit 969de30](https://github.com/tcurdt/jdependency/commit/969de30) => [run url](https://github.com/tcurdt/jdependency/actions/runs/14354461115)
[commit b4d8003](https://github.com/tcurdt/jdependency/commit/b4d8003) => [run url](https://github.com/tcurdt/jdependency/actions/runs/14149760848)
[commit 6b155b8](https://github.com/tcurdt/jdependency/commit/6b155b8) => [run url](https://github.com/tcurdt/jdependency/actions/runs/10918857603)
[commit 6b155b8](https://github.com/tcurdt/jdependency/commit/6b155b8) => [run url](https://github.com/tcurdt/jdependency/actions/runs/10918920860)
[commit b579897](https://github.com/tcurdt/jdependency/commit/b579897) => [run url](https://github.com/tcurdt/jdependency/actions/runs/14356115640)
[commit 5091190](https://github.com/tcurdt/jdependency/commit/5091190) => [run url](https://github.com/tcurdt/jdependency/actions/runs/13099183809)
[commit 90df888](https://github.com/tcurdt/jdependency/commit/90df888) => [run url](https://github.com/tcurdt/jdependency/actions/runs/10918338025)

</details>

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on optimizations in GitHub Actions workflows.

Thanks for your time on this.

Kindly let us know (here or in the email below) if you would like to ignore other file types or apply the filter to other workflows/triggers, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch