### PR TITLE
ASM-less artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,11 @@
           <artifactId>maven-site-plugin</artifactId>
           <version>3.21.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.6.1</version>
+        </plugin>
         <!-- Release plugins -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -294,6 +299,30 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-asmless-artifact</id>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <!-- Note: this path relies on m-shade-p config; if that changes, update here may be needed -->
+                  <file>${project.build.directory}/original-${project.artifactId}-${project.version}.jar</file>
+                  <type>jar</type>
+                  <classifier>classes</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Following same pattern as Guice by using `classes` classifier for ASM-less JAR.

See MC for Guice: https://repo.maven.apache.org/maven2/com/google/inject/guice/6.0.0/

With this PR following artifacts are produced by the build (installed and deployed):
* `org.vafer:jdependency:pom:2.15` - the POM
* `org.vafer:jdependency:jar:2.15` - the JAR as before (w/ shaded ASM)
* `org.vafer:jdependency:jar:classes:2.15` - the "classes only" (as before shading)

Fixes #389 